### PR TITLE
Use the group id of the parent part when creating a new module

### DIFF
--- a/shared/gh/js/utils/gh.utils.orgunits.js
+++ b/shared/gh/js/utils/gh.utils.orgunits.js
@@ -65,6 +65,16 @@ define(['exports'], function(exports) {
     };
 
     /**
+     * Get a part by its id
+     *
+     * @param  {Number}     partId      The id of the part to retrieve
+     * @return {Object}                 The organisational unit that represents the part
+     */
+    var getPartById = exports.getPartById = function(partId) {
+        return _.find(_triposData.parts, {'id': partId});
+    };
+
+    /**
      * Decorate an organisational unit with its parent info
      *
      * @param  {Object}    orgUnit    The organisational unit that needs to be decorated with his parent info

--- a/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
@@ -967,7 +967,10 @@ define(['gh.core', 'gh.constants', 'moment', 'moment-timezone', 'gh.calendar', '
         var createNewEvent = function(newEvent, _callback) {
             // Get the ID of the series this event is added to
             var seriesId = parseInt(History.getState().data['series'], 10);
-            gh.api.eventAPI.createEvent(newEvent.displayName, newEvent.start, newEvent.end, null, null, newEvent.location, newEvent.notes, newEvent.organiserOther, newEvent.organiserUsers, seriesId, newEvent.type, function(evErr, data) {
+            // Get the Group Id of the part under which this series is being added
+            var partId = parseInt(History.getState().data['part'], 10);
+            var part = gh.utils.getPartById(partId);
+            gh.api.eventAPI.createEvent(newEvent.displayName, newEvent.start, newEvent.end, null, part.GroupId, newEvent.location, newEvent.notes, newEvent.organiserOther, newEvent.organiserUsers, seriesId, newEvent.type, function(evErr, data) {
                 var $row = $('.gh-batch-edit-events-container tbody tr[data-tempid="' + newEvent.tempId + '"]');
                 if (evErr) {
                     hasError = true;

--- a/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
@@ -952,6 +952,25 @@ define(['gh.core', 'gh.constants', 'moment', 'moment-timezone', 'gh.calendar', '
             return callback(null);
         }
 
+        // Get the ID of the series this event is added to
+        var seriesId = parseInt(History.getState().data['series'], 10);
+
+        // Get the part under which this series is being added. We need the full object as we should
+        // re-use the group id of the part. Technically we should re-use the group id of the series
+        // this event is being added to, but neither the series nor the module object is easily accessible
+        var partId = parseInt(History.getState().data['part'], 10);
+        var part = gh.utils.getPartById(partId);
+
+        // If the part could not be found there's something seriously wrong (or fishy). Mark each
+        // row in red and immediately call the callback
+        if (!part) {
+            _.each(newEventObjs, function(newEvent) {
+                var $row = $('.gh-batch-edit-events-container tbody tr[data-tempid="' + newEvent.tempId + '"]');
+                $row.addClass('danger');
+            });
+            return callback(true);
+        }
+
         var done = 0;
         var todo = newEventObjs.length;
         var hasError = false;
@@ -965,11 +984,6 @@ define(['gh.core', 'gh.constants', 'moment', 'moment-timezone', 'gh.calendar', '
          * @private
          */
         var createNewEvent = function(newEvent, _callback) {
-            // Get the ID of the series this event is added to
-            var seriesId = parseInt(History.getState().data['series'], 10);
-            // Get the Group Id of the part under which this series is being added
-            var partId = parseInt(History.getState().data['part'], 10);
-            var part = gh.utils.getPartById(partId);
             gh.api.eventAPI.createEvent(newEvent.displayName, newEvent.start, newEvent.end, null, part.GroupId, newEvent.location, newEvent.notes, newEvent.organiserOther, newEvent.organiserUsers, seriesId, newEvent.type, function(evErr, data) {
                 var $row = $('.gh-batch-edit-events-container tbody tr[data-tempid="' + newEvent.tempId + '"]');
                 if (evErr) {

--- a/shared/gh/partials/tenant-admin/admin-modules.html
+++ b/shared/gh/partials/tenant-admin/admin-modules.html
@@ -1,13 +1,13 @@
-<% var partId = data.state.part; %>
-<% if (data.modules.length) {
-    var groupId = data.modules[0].GroupId;
-} %>
+<%
+    var partId = parseInt(data.state.part, 10);
+    var part = data.utils.getPartById(partId);
+%>
 <div id="gh-result-summary">
     <button class="btn btn-default gh-btn-secondary gh-btn-reverse pull-right gh-collapse-modules" title="Toggle the modules list">
         <i class="fa fa-angle-double-left"></i>
         <i class="fa fa-angle-double-right"></i>
     </button>
-    <button type="button" class="btn btn-default gh-btn-secondary gh-btn-reverse gh-new-module" data-partid="<%= partId %>" data-groupid="<%= groupId %>"><i class="fa fa-plus-square"></i> New module</button>
+    <button type="button" class="btn btn-default gh-btn-secondary gh-btn-reverse gh-new-module" data-partid="<%= partId %>" data-groupid="<%= part.GroupId %>"><i class="fa fa-plus-square"></i> New module</button>
 </div>
 <div id="gh-modules-list-container" data-partId="<%= partId %>">
     <ul id="gh-modules-list" class="list-group">

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -1171,6 +1171,28 @@ require(['gh.core', 'moment', 'gh.api.orgunit', 'gh.api.tests'], function(gh, mo
         assert.ok(_triposData.parts);
     });
 
+    // Test the 'getPartById' functionality
+    QUnit.asyncTest('getPartById', function(assert) {
+        expect(5);
+
+        // Retrieve the tripos structure for the test application and cache it
+        var testApp = testAPI.getTestApp();
+        gh.utils.getTriposStructure(testApp.id, false, function(err, data) {
+            assert.ok(!err, 'Verify that the tripos structure can be requested without errors');
+
+            // Get a part by its id
+            var part = gh.utils.getPartById(7);
+            assert.ok(part);
+            assert.ok(part.id);
+            assert.ok(part.GroupId);
+
+            // Getting a part with an unknown id should return null
+            var part = gh.utils.getPartById(7324234);
+            assert.ok(!part);
+            QUnit.start();
+        });
+    });
+
 
     //////////////////
     //  BATCH EDIT  //


### PR DESCRIPTION
This fixes a bug where a new module is created under an empty part.
