### PR TITLE
Batch edit bugs

### DIFF
--- a/shared/gh/js/utils/gh.utils.time.js
+++ b/shared/gh/js/utils/gh.utils.time.js
@@ -210,7 +210,10 @@ define(['exports', 'gh.constants', 'moment', 'moment-timezone'], function(export
         // Get the current term and return its name
         return _.find(terms, function(term) {
 
-            // Convert the dates from ISO to UNIX for easier calculation
+            // Convert the dates from ISO to UNIX for easier calculation. Keep in mind that the configured
+            // start and end term dates are the official term start and end. Within the Timetable context
+            // however, a term starts 2 days later and ends 2 days earlier. Keep in mind that the configured
+            // term start/end doesn't have a time component, so we ensure the range ends at 23:59:59.
             var startDate = convertISODatetoUnixDate(moment.tz(term.start, 'Europe/London').add({'days': 2}).toISOString());
             var endDate = convertISODatetoUnixDate(moment.tz(term.end, 'Europe/London').subtract({'days': 2}).hours(23).minutes(59).seconds(59).toISOString());
 
@@ -262,7 +265,10 @@ define(['exports', 'gh.constants', 'moment', 'moment-timezone'], function(export
             throw new Error('A valid term should be provided');
         }
 
-        // Convert the term start and end date to milliseconds
+        // Convert the dates from ISO to UNIX for easier calculation. Keep in mind that the configured
+        // start and end term dates are the official term start and end. Within the Timetable context
+        // however, a term starts 2 days later and ends 2 days earlier. Keep in mind that the configured
+        // term start/end doesn't have a time component, so we ensure the range ends at 23:59:59.
         var termStartDate = moment(term.start).add({'days': 2});
         var termEndDate = moment(term.end).subtract({'days': 2}).hours(23).minutes(59).seconds(59);
 

--- a/shared/gh/js/utils/gh.utils.time.js
+++ b/shared/gh/js/utils/gh.utils.time.js
@@ -212,7 +212,7 @@ define(['exports', 'gh.constants', 'moment', 'moment-timezone'], function(export
 
             // Convert the dates from ISO to UNIX for easier calculation
             var startDate = convertISODatetoUnixDate(moment.tz(term.start, 'Europe/London').add({'days': 2}).toISOString());
-            var endDate = convertISODatetoUnixDate(moment.tz(term.end, 'Europe/London').subtract({'days': 2}).toISOString());
+            var endDate = convertISODatetoUnixDate(moment.tz(term.end, 'Europe/London').subtract({'days': 2}).hours(23).minutes(59).seconds(59).toISOString());
 
             // Return the term where the specified date is within the range
             if (isDateInRange(date, startDate, endDate)) {
@@ -264,7 +264,7 @@ define(['exports', 'gh.constants', 'moment', 'moment-timezone'], function(export
 
         // Convert the term start and end date to milliseconds
         var termStartDate = moment(term.start).add({'days': 2});
-        var termEndDate = moment(term.end).subtract({'days': 2});
+        var termEndDate = moment(term.end).subtract({'days': 2}).hours(23).minutes(59).seconds(59);
 
         // Calculate the time difference
         var timeDifference = Math.abs(termEndDate - termStartDate);

--- a/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
@@ -216,7 +216,7 @@ define(['gh.core', 'gh.constants', 'moment', 'moment-timezone', 'gh.calendar', '
         // all of them starting on the same day in week 1
         var addRow = function(i) {
             addNewEventRow(ev, {
-                'eventContainer': $eventContainer,
+                'eventContainer': $eventContainer
             }, function() {
                 if (i < weeksInTerm) {
                     addRow(i + 1);

--- a/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
@@ -123,11 +123,13 @@ define(['gh.core', 'gh.constants', 'moment', 'moment-timezone', 'gh.calendar', '
     /**
      * Add a new event row to the table and initialise the editable fields in it
      *
-     * @param {Event}     ev      Standard jQuery event
-     * @param {Object}    data    Data object containing the event object to create and its container
+     * @param {Event}       ev              Standard jQuery event
+     * @param {Object}      data            Data object containing the event object to create and its container
+     * @param {Function}    [callback]      Standard callback function
      * @private
      */
-    var addNewEventRow = function(ev, data) {
+    var addNewEventRow = function(ev, data, callback) {
+        callback = callback || function() {};
         var $eventContainer = data && data.eventContainer ? $(data.eventContainer) : $(this).closest('thead').next('tbody');
         var termName = $eventContainer.closest('.gh-batch-edit-events-container').data('term');
         var termStart = gh.utils.getFirstLectureDayOfTerm(termName);
@@ -186,6 +188,7 @@ define(['gh.core', 'gh.constants', 'moment', 'moment-timezone', 'gh.calendar', '
             $eventContainer.find('.gh-select-single').trigger('change');
             // Sort the table
             sortEventTable($eventContainer);
+            callback();
         });
     };
 
@@ -203,13 +206,25 @@ define(['gh.core', 'gh.constants', 'moment', 'moment-timezone', 'gh.calendar', '
         });
         // Get the number of weeks in the term
         var weeksInTerm = gh.utils.getWeeksInTerm(term);
-        // Add a new event row for every week in the term
-        for (weeksInTerm; weeksInTerm !== 0; weeksInTerm--) {
-            // Add new event rows
+
+        // The container where the event rows should be added to
+        var $eventContainer = $(this).closest('.gh-batch-edit-events-container').find('tbody');
+
+        // This recursive loop is necessary because `addNewEventRow` is asynchronous. On its own, this
+        // wouldn't be a huge problem, but `addNewEventRow` checks the DOM to see how many rows have
+        // been added previously. If this were executed synchronously 8 times, it would add 8 events
+        // all of them starting on the same day in week 1
+        var addRow = function(i) {
             addNewEventRow(ev, {
-                'eventContainer': $(this).closest('.gh-batch-edit-events-container').find('tbody'),
+                'eventContainer': $eventContainer,
+            }, function() {
+                if (i < weeksInTerm) {
+                    addRow(i + 1);
+                }
             });
-        }
+        };
+        addRow(1);
+
         // Track the user adding events for an empty term
         gh.utils.trackEvent(['Data', 'Added events for empty term']);
     };

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -204,6 +204,24 @@ require(['gh.core', 'moment', 'gh.api.orgunit', 'gh.api.tests'], function(gh, mo
         // Verify that no term is returned when specifying an out-of-term date
         term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate('2015-01-01T10:30:00.000Z'));
         assert.ok(!term);
+
+        // Verify the correct term is returned when the first day of term is passed in
+        term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate('2014-10-09T10:00:00.000Z'));
+        assert.ok(term);
+        assert.strictEqual(term.name, 'michaelmas', 'Verify that the corresponding term is returned');
+
+        // Verify the correct term is returned when the last day of term is passed in
+        term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate('2014-12-03T10:00:00.000Z'));
+        assert.ok(term);
+        assert.strictEqual(term.name, 'michaelmas', 'Verify that the corresponding term is returned');
+
+        // Verify no term is returned when the day before term starts is passed in
+        term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate('2014-10-08T10:00:00.000Z'));
+        assert.ok(!term);
+
+        // Verify no term is returned when the day after term ends is passed in
+        term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate('2014-12-04T10:00:00.000Z'));
+        assert.ok(!term);
     });
 
     // Test the 'getWeeksInTerm' functionality


### PR DESCRIPTION
This PR fixes 2 bugs (1 reported) in the batch editor.
### Adding an event on the last day of term

To reproduce:
- Add events in the michaelmas term
- Select week 8
- Select wednesday as the day
  Result: an OT checkbox appears (this shouldn't appear, as the last day of term .. is stil in the term)

The UI has the official dates of when the term starts in a Tuesday - Friday format. For example, for the michaelmas term of this year that's:
- term.start: 2015-10-06T00:00:00 (Tuesday)
- term.end: 2015-12-04T00:00:00 (Friday)

The first term week starts on Thursday 2015/10/08 and ends on Wednesday 2015/12/02. However, because they were calculating the range as:
- firstWeekStart = term.start.add(2 days) = 2015-10-04T00:00:00
- lastWeekEnds = term.end.subtract(2 days) = 2015-12-02T00:00:00

When a timetable admin adds an event on the last day of term at say 2pm you end up with the following date: 2015-12-02T14:00:00. Which doesn't fall in that range.

The fix sets the hours, minutes and seconds to 23:59:59 to avoid this
### Clicking add events generates 8 events in the first week rather than one for each week

This is because they were using the DOM to check how many events were added already. However, because the template rendering mechanisme is async, the events weren't in the DOM yet. I've made the for loop recursive which fixed it.
